### PR TITLE
Remove check for app install vs. content ad

### DIFF
--- a/adapters/MoPub/CHANGELOG.md
+++ b/adapters/MoPub/CHANGELOG.md
@@ -1,5 +1,8 @@
 # MoPub Ads Mediation Adapter for Google Mobile Ads SDK for iOS
 
+## Version 5.3.0.2
+- Remove the check that prevents ad requests for native content ad.
+
 ## Version 5.3.0.1
 - Initialize MoPub and reattempt ad requests manually in the adapters for use cases that do not do so in the app.
 

--- a/adapters/MoPub/MoPubAdapter/GADMAdapterMoPub.m
+++ b/adapters/MoPub/MoPubAdapter/GADMAdapterMoPub.m
@@ -245,12 +245,6 @@ static NSString *const kAdapterTpValue = @"gmext";
 #pragma mark - Native Ads
 
 - (void)getNativeAdWithAdTypes:(NSArray *)adTypes options:(NSArray *)options {
-  if (![adTypes containsObject:kGADAdLoaderAdTypeNativeAppInstall]) {
-    NSError *adapterError =
-        [NSError errorWithDomain:kAdapterErrorDomain code:kGADErrorInvalidArgument userInfo:nil];
-    [_connector adapter:self didFailAd:adapterError];
-    return;
-  }
 
   MPStaticNativeAdRendererSettings *settings = [[MPStaticNativeAdRendererSettings alloc] init];
   MPNativeAdRendererConfiguration *config =


### PR DESCRIPTION
* Remove the check that distinguishes between AdMob's app install and content native ads (since Google started supporting the unified native ad).